### PR TITLE
Create _routes.json to ignore Cloudflare function invocation on asset routes

### DIFF
--- a/public/_routes.json
+++ b/public/_routes.json
@@ -1,0 +1,5 @@
+{
+  "version": 1,
+  "include": ["/*"],
+  "exclude": ["/assets/*", "/favicon.ico"]
+}


### PR DESCRIPTION
Currently there's a function invocation for every route, including client assets. These count against fn invocation limits.

We can define a `_routes.json` file to ignore invocations for certain paths. See [the CF Functions Routing docs](https://developers.cloudflare.com/pages/functions/routing/#functions-invocation-routes).